### PR TITLE
fixes

### DIFF
--- a/htdocs/luci-static/proton2025/cascade.css
+++ b/htdocs/luci-static/proton2025/cascade.css
@@ -70,7 +70,7 @@
     /* Text Colors */
     --proton-fg: #f5f7fa;
     --proton-fg-secondary: #c5cad5;
-    --proton-muted: #8b92a8;
+    --proton-muted: #9299a8;
 
     /* Accent Colors */
     --proton-accent: #5e9eff;
@@ -103,7 +103,7 @@
     --proton-transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 
     /* Layout */
-    --proton-page-max-width: 990px;
+    --proton-page-max-width: none;
     --proton-page-gutter: 20px;
 
     /* Legacy compatibility */
@@ -405,6 +405,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     letter-spacing: 0.01em;
+    overflow-x: hidden;
 }
 
 /* Light theme background gradients */
@@ -1049,8 +1050,9 @@ a:active {
     padding: 24px var(--proton-page-gutter);
     padding-bottom: 120px;
     min-width: 0;
-    overflow-x: auto;
-    overflow-y: visible;
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: auto;
     animation: fadeIn 0.4s ease-out;
 }
 
@@ -1558,6 +1560,23 @@ textarea {
     max-width: 100%;
 }
 
+/* Ace editor uses a hidden <textarea class="ace_text-input"> for
+   keyboard/clipboard. Our global textarea rules break its clipboard
+   sync (padding shifts the selection offset, focus box-shadow makes
+   it visible, transition delays selection updates). Reset here. */
+.ace_text-input {
+    padding: 0 !important;
+    margin: 0 !important;
+    min-height: 0 !important;
+    max-width: none !important;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    transition: none !important;
+    outline: none !important;
+    resize: none !important;
+}
+
 /* Checkbox & Radio */
 input[type="checkbox"],
 input[type="radio"] {
@@ -1877,6 +1896,7 @@ table:has(.cbi-section-actions) {
     overflow: visible;
 }
 
+
 th {
     background: var(--proton-bg-secondary);
     color: var(--proton-fg-secondary);
@@ -1972,17 +1992,75 @@ tr:hover td {
     }
 }
 
-/* Table cells with inputs and control-groups */
+/* Table cells with inputs and control-groups.
+   The global input rule has max-width: 400px which makes table-layout: auto
+   treat the column's max-content contribution as 400px. With a 240px sidebar
+   only ~1006px is available, so a single 400px input column plus buttons and
+   data columns causes horizontal overflow. max-width: none removes the cap and
+   lets the column size to the input's intrinsic width (~170px), which fits. */
 td input:not([type]),
 td input[type="text"],
 td input[type="password"],
 td select,
-td .cbi-dropdown:not(.btn):not(.cbi-button),
 td .cbi-dynlist,
 td .control-group {
-    /* Allow table cells to shrink instead of forcing overflow */
     min-width: 0;
     width: 100%;
+    max-width: none;
+}
+
+td .cbi-dropdown:not(.btn):not(.cbi-button) {
+    display: flex !important;
+    min-width: 0 !important;
+    max-width: 100%;
+    width: 100%;
+}
+
+/* =====================================================
+   CBI Section-Table: compact layout so tables fit
+   inside the ~910px content area without page scroll.
+
+   Root cause: the action cell has class "nowrap" (set
+   by form.js) which forces all buttons side-by-side.
+   With 3 Cyrillic buttons (Изменить/Удалить/Копировать)
+   that alone takes 280-320px. Reduce button padding and
+   eliminate the double-gap (flex gap + margin-left).
+   ===================================================== */
+
+/* Tighter header and data cells */
+table.cbi-section-table th {
+    padding: 8px 10px;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.82rem;
+}
+
+table.cbi-section-table td {
+    padding: 8px 10px;
+}
+
+/* Compact action buttons */
+table.cbi-section-table td.cbi-section-actions .cbi-button,
+table.cbi-section-table td.cbi-section-actions .btn,
+table.cbi-section-table td.cbi-section-actions button {
+    padding: 4px 8px !important;
+    font-size: 0.8rem !important;
+    min-height: unset;
+}
+
+/* Single gap only */
+table.cbi-section-table .cbi-section-actions > div {
+    gap: 4px;
+}
+
+table.cbi-section-table .cbi-section-actions button + button,
+table.cbi-section-table .cbi-section-actions .btn + .btn,
+table.cbi-section-table .cbi-section-actions .cbi-button + .cbi-button {
+    margin-left: 0;
+}
+
+body:not([data-page^="admin-status"]) .cbi-tblsection {
+    overflow-x: auto;
 }
 
 /* Status page: Associated Stations table can contain very long labels (AP name + phy).
@@ -3583,6 +3661,7 @@ table.assoclist td[data-title="Скорость приёма / отправки"
     padding: 0;
     display: flex;
     width: 100%;
+    min-width: 0;
     overflow-x: hidden;
     overflow-y: auto;
 }
@@ -4103,6 +4182,8 @@ body[data-page^="admin-status"] .cbi-section>div>div[style*="display:grid"] {
     gap: 16px;
     justify-content: flex-start;
     margin: 0;
+    max-width: 100%;
+    overflow-x: auto;
 }
 
 /*
@@ -4676,15 +4757,15 @@ body.modal-overlay-active #modal_overlay {
         z-index: -1;
         background: var(--proton-bg-solid);
         background-image:
-            radial-gradient(circle at 20% 30%, rgba(94, 158, 255, 0.06) 0%, transparent 50%),
-            radial-gradient(circle at 80% 70%, rgba(107, 207, 127, 0.04) 0%, transparent 50%),
+            radial-gradient(circle at 20% 30%, rgba(var(--proton-accent-rgb), 0.06) 0%, transparent 50%),
+            radial-gradient(circle at 80% 70%, rgba(var(--proton-accent-rgb), 0.03) 0%, transparent 50%),
             var(--proton-bg);
     }
 
     :root[data-theme="light"] body::before {
         background-image:
-            radial-gradient(circle at 20% 30%, rgba(74, 143, 231, 0.04) 0%, transparent 50%),
-            radial-gradient(circle at 80% 70%, rgba(72, 187, 120, 0.03) 0%, transparent 50%),
+            radial-gradient(circle at 20% 30%, rgba(var(--proton-accent-rgb), 0.04) 0%, transparent 50%),
+            radial-gradient(circle at 80% 70%, rgba(var(--proton-accent-rgb), 0.025) 0%, transparent 50%),
             var(--proton-bg);
     }
 
@@ -7510,7 +7591,6 @@ body[data-page="admin-system-leds"] #cbi-system-led .cbi-section-table {
     background: var(--proton-bg-secondary);
     border: 1px solid var(--proton-border);
     border-radius: var(--proton-radius);
-    overflow: hidden;
 }
 
 body[data-page="admin-system-leds"] #cbi-system-led .cbi-section-table-titles {
@@ -7518,12 +7598,10 @@ body[data-page="admin-system-leds"] #cbi-system-led .cbi-section-table-titles {
 }
 
 body[data-page="admin-system-leds"] #cbi-system-led .cbi-section-table-titles .th {
-    padding: 12px 16px;
+    padding: 8px 10px;
     font-weight: 600;
     color: var(--proton-fg);
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
+    font-size: 0.82rem;
     border-bottom: 1px solid var(--proton-border);
 }
 
@@ -7541,9 +7619,9 @@ body[data-page="admin-system-leds"] #cbi-system-led .cbi-section-table-row:last-
 }
 
 body[data-page="admin-system-leds"] #cbi-system-led .cbi-section-table-row .td {
-    padding: 12px 16px;
+    padding: 8px 10px;
     vertical-align: middle;
-    font-size: 0.9rem;
+    font-size: 0.88rem;
 }
 
 /* Name field */
@@ -7552,7 +7630,7 @@ body[data-page="admin-system-leds"] #cbi-system-led .td[data-title="Name"] {
     color: var(--proton-fg);
 }
 
-/* LED Name - monospace with accent */
+/* LED Name - monospace with accent color */
 body[data-page="admin-system-leds"] #cbi-system-led .td[data-title="LED Name"] {
     font-family: 'SF Mono', 'Monaco', 'Inconsolata', monospace;
     color: var(--proton-accent);
@@ -7599,8 +7677,6 @@ body[data-page="admin-system-leds"] #cbi-system-led .cbi-button-edit {
     background: var(--proton-accent) !important;
     border-color: var(--proton-accent) !important;
     color: #fff !important;
-    padding: 6px 12px !important;
-    font-size: 0.8rem !important;
     border-radius: var(--proton-radius-sm) !important;
 }
 
@@ -7612,8 +7688,6 @@ body[data-page="admin-system-leds"] #cbi-system-led .cbi-button-remove {
     background: rgba(255, 107, 107, 0.1) !important;
     border-color: rgba(255, 107, 107, 0.3) !important;
     color: var(--proton-danger) !important;
-    padding: 6px 12px !important;
-    font-size: 0.8rem !important;
     border-radius: var(--proton-radius-sm) !important;
 }
 
@@ -10742,6 +10816,11 @@ body[data-page="admin-status-overview"] .cbi-section:first-of-type table.table t
     box-shadow: 0 0 6px var(--proton-danger);
 }
 
+.proton-service-status-dot.unknown {
+    background: #ffc107;
+    box-shadow: 0 0 6px rgba(255, 193, 7, 0.4);
+}
+
 .proton-service-status-dot.not-installed {
     background: var(--proton-muted);
     opacity: 0.5;
@@ -10764,6 +10843,10 @@ body[data-page="admin-status-overview"] .cbi-section:first-of-type table.table t
 
 .proton-service-status-text.error {
     color: var(--proton-danger);
+}
+
+.proton-service-status-text.unknown {
+    color: #ffc107;
 }
 
 .proton-service-status-text.not-installed {
@@ -12271,6 +12354,10 @@ body.proton-custom-page .table {
     box-shadow: none;
 }
 
+body.proton-custom-page .table .tr {
+    display: table-row;
+}
+
 body.proton-custom-page .table .th,
 body.proton-custom-page .table .td {
     display: table-cell;
@@ -12372,19 +12459,15 @@ body.proton-custom-page table td {
     padding: 8px 10px;
 }
 
-/* Hide empty cbi-section-table-descr on custom pages */
-body.proton-custom-page .cbi-section-table-descr {
-    display: none;
-}
-
-/* Or if it has content, make it minimal */
-body.proton-custom-page .cbi-section-table-descr .th,
-body.proton-custom-page .cbi-section-table-descr th {
+/* Collapse empty cbi-section-table-descr rows on custom pages.
+   Do NOT use display:none — some apps render their column-title row
+   with this class, so hiding it would drop the entire header. */
+body.proton-custom-page .cbi-section-table-descr th:empty,
+body.proton-custom-page .cbi-section-table-descr .th:empty {
     padding: 0;
-    border: none;
-    height: 0;
     line-height: 0;
     font-size: 0;
+    border: none;
 }
 
 
@@ -13595,4 +13678,410 @@ body.proton-log-fs-active #maincontainer {
     background: var(--proton-accent) !important;
     color: #fff !important;
     border-color: var(--proton-accent) !important;
+}
+
+/* =====================================================
+   luci-mod-dashboard — card background fix
+   luci-mod-dashboard renders cards as .Dashboard .dashboard-bg
+   using --background-color-medium (#1a1f2e, hardcoded dark).
+   Override to use an accent-aware semi-transparent background
+   consistent with the rest of the theme.
+   ===================================================== */
+body[data-page^="admin-dashboard"] .Dashboard .dashboard-bg {
+    background: rgba(var(--proton-accent-rgb), 0.07) !important;
+    border: 1px solid var(--proton-border) !important;
+    box-shadow: var(--proton-shadow-sm) !important;
+}
+
+:root[data-theme="light"] body[data-page^="admin-dashboard"] .Dashboard .dashboard-bg {
+    background: rgba(0, 0, 0, 0.025) !important;
+    border: 1px solid rgba(0, 0, 0, 0.1) !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04) !important;
+}
+
+body[data-page^="admin-dashboard"] .cbi-section {
+    background: var(--proton-bg-secondary) !important;
+    border-color: var(--proton-border) !important;
+}
+
+:root[data-theme="light"] body[data-page^="admin-dashboard"] .cbi-section {
+    background: var(--proton-bg-secondary) !important;
+    border-color: rgba(0, 0, 0, 0.1) !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04) !important;
+}
+
+/* =====================================================
+   luci-mod-dashboard — SVG icon theme fix
+   Dashboard icons (router.svg, wireless.svg, devices.svg,
+   not-internet.svg) have hardcoded stroke="#000".
+   The dashboard's own custom.css uses [data-darkmode="true"]
+   which our theme never sets — so icons stay black in dark mode.
+   Mirror the invert logic using our data-theme attribute.
+   ===================================================== */
+body[data-page^="admin-dashboard"] .Dashboard .svgmonotone {
+    filter: invert(1);
+}
+
+:root[data-theme="light"] body[data-page^="admin-dashboard"] .Dashboard .svgmonotone {
+    filter: none;
+}
+
+
+/* =====================================================
+   SSClash / Mihomo — Dark theme adaptation
+   settings.js and config.js build all UI with hardcoded
+   inline light-palette styles. CSS [style*] selectors
+   with !important override inline styles in the cascade.
+   ===================================================== */
+
+/* ── Common containers: white / near-white backgrounds ── */
+body[data-page*="ssclash"] [style*="background: white"],
+body[data-page*="ssclash"] [style*="background: #fff"],
+body[data-page*="ssclash"] [style*="background: #f9f9f9"],
+body[data-page*="ssclash"] [style*="background: #f8f9fa"],
+body[data-page*="ssclash"] [style*="background: #f8f8f8"],
+body[data-page*="ssclash"] [style*="background-color: white"],
+body[data-page*="ssclash"] [style*="background-color: #fff"],
+body[data-page*="ssclash"] [style*="background-color: #f9f9f9"],
+body[data-page*="mihomo"] [style*="background: white"],
+body[data-page*="mihomo"] [style*="background: #fff"],
+body[data-page*="mihomo"] [style*="background: #f9f9f9"],
+body[data-page*="mihomo"] [style*="background: #f8f9fa"],
+body[data-page*="mihomo"] [style*="background-color: white"],
+body[data-page*="mihomo"] [style*="background-color: #fff"],
+body[data-page*="mihomo"] [style*="background-color: #f9f9f9"] {
+    background-color: var(--proton-bg-secondary) !important;
+}
+
+/* ── Info / hint panels (light blue, green, yellow tints) ── */
+body[data-page*="ssclash"] [style*="background: #e6f3ff"],
+body[data-page*="ssclash"] [style*="background: #f0f8ff"],
+body[data-page*="ssclash"] [style*="background-color: #f0f8ff"],
+body[data-page*="mihomo"] [style*="background: #e6f3ff"],
+body[data-page*="mihomo"] [style*="background: #f0f8ff"],
+body[data-page*="mihomo"] [style*="background-color: #f0f8ff"] {
+    background-color: rgba(var(--proton-accent-rgb), 0.08) !important;
+}
+
+body[data-page*="ssclash"] [style*="background: #e8f5e8"],
+body[data-page*="ssclash"] [style*="background: #f8fff8"],
+body[data-page*="mihomo"] [style*="background: #e8f5e8"],
+body[data-page*="mihomo"] [style*="background: #f8fff8"] {
+    background-color: rgba(40, 167, 69, 0.12) !important;
+}
+
+body[data-page*="ssclash"] [style*="background: #fff3cd"],
+body[data-page*="mihomo"] [style*="background: #fff3cd"] {
+    background-color: rgba(255, 193, 7, 0.12) !important;
+}
+
+/* ── Text: dark text on light background → proton fg ── */
+body[data-page*="ssclash"] [style*="color: #1f2937"],
+body[data-page*="ssclash"] [style*="color: #4b5563"],
+body[data-page*="ssclash"] [style*="color: #374151"],
+body[data-page*="mihomo"] [style*="color: #1f2937"],
+body[data-page*="mihomo"] [style*="color: #4b5563"],
+body[data-page*="mihomo"] [style*="color: #374151"] {
+    color: var(--proton-fg) !important;
+}
+
+body[data-page*="ssclash"] [style*="color: #856404"],
+body[data-page*="mihomo"] [style*="color: #856404"] {
+    color: #e9c46a !important;
+}
+
+body[data-page*="ssclash"] [style*="color: #155724"],
+body[data-page*="mihomo"] [style*="color: #155724"] {
+    color: #6fcf97 !important;
+}
+
+/* ── Borders: light grey → proton border ── */
+body[data-page*="ssclash"] [style*="border: 1px solid #ddd"],
+body[data-page*="ssclash"] [style*="border: 2px solid #ddd"],
+body[data-page*="ssclash"] [style*="border: 1px solid #ccc"],
+body[data-page*="ssclash"] [style*="border-color: #ddd"],
+body[data-page*="ssclash"] [style*="border-color: #ccc"],
+body[data-page*="mihomo"] [style*="border: 1px solid #ddd"],
+body[data-page*="mihomo"] [style*="border: 2px solid #ddd"],
+body[data-page*="mihomo"] [style*="border: 1px solid #ccc"],
+body[data-page*="mihomo"] [style*="border-color: #ddd"],
+body[data-page*="mihomo"] [style*="border-color: #ccc"] {
+    border-color: var(--proton-border) !important;
+}
+
+/* ── Split-button save dropdown ── */
+body[data-page*="ssclash"] .ssclash-split-menu,
+body[data-page*="mihomo"] .ssclash-split-menu {
+    background: var(--proton-bg-secondary) !important;
+    color: var(--proton-fg) !important;
+    border-color: var(--proton-border) !important;
+    box-shadow: var(--proton-shadow-lg) !important;
+}
+
+body[data-page*="ssclash"] .ssclash-split-menu button,
+body[data-page*="mihomo"] .ssclash-split-menu button {
+    color: var(--proton-fg) !important;
+}
+
+body[data-page*="ssclash"] .ssclash-split-menu button:hover,
+body[data-page*="mihomo"] .ssclash-split-menu button:hover {
+    background: var(--proton-bg-hover) !important;
+}
+
+/* ── Footer version line ── */
+body[data-page*="ssclash"] #ssclash-version-footer,
+body[data-page*="mihomo"] #ssclash-version-footer {
+    color: var(--proton-muted) !important;
+    border-top-color: var(--proton-border) !important;
+}
+
+/* ── Status label (running / stopped) ── */
+body[data-page*="ssclash"] [style*="background-color: #5cb85c"],
+body[data-page*="mihomo"] [style*="background-color: #5cb85c"] {
+    background-color: #2d8a4e !important;
+}
+
+body[data-page*="ssclash"] [style*="background-color: #d9534f"],
+body[data-page*="mihomo"] [style*="background-color: #d9534f"] {
+    background-color: #a63030 !important;
+}
+
+/* ── Accent blue #0066cc: active options (settings), technical list, status panel (rulesets) ── */
+body[data-page*="ssclash"] [style*="background: #0066cc"],
+body[data-page*="mihomo"] [style*="background: #0066cc"] {
+    background-color: var(--proton-accent) !important;
+}
+
+/* rgba(0,102,204,…) — set via JS DOM (with spaces) or via setAttribute string (no spaces) */
+body[data-page*="ssclash"] [style*="background-color: rgba(0,102,204"],
+body[data-page*="ssclash"] [style*="background-color: rgba(0, 102, 204"],
+body[data-page*="ssclash"] [style*="background: rgba(0,102,204"],
+body[data-page*="ssclash"] [style*="background: rgba(0, 102, 204"],
+body[data-page*="mihomo"] [style*="background-color: rgba(0,102,204"],
+body[data-page*="mihomo"] [style*="background-color: rgba(0, 102, 204"],
+body[data-page*="mihomo"] [style*="background: rgba(0,102,204"],
+body[data-page*="mihomo"] [style*="background: rgba(0, 102, 204"] {
+    background-color: rgba(var(--proton-accent-rgb), 0.15) !important;
+}
+
+/* border #0066cc — set via setAttribute string or via JS DOM (normalised to rgb()) */
+body[data-page*="ssclash"] [style*="border: 2px solid #0066cc"],
+body[data-page*="ssclash"] [style*="border-left: 4px solid #0066cc"],
+body[data-page*="ssclash"] [style*="border-color: #0066cc"],
+body[data-page*="ssclash"] [style*="border-color: rgb(0, 102, 204"],
+body[data-page*="mihomo"] [style*="border: 2px solid #0066cc"],
+body[data-page*="mihomo"] [style*="border-left: 4px solid #0066cc"],
+body[data-page*="mihomo"] [style*="border-color: #0066cc"],
+body[data-page*="mihomo"] [style*="border-color: rgb(0, 102, 204"] {
+    border-color: var(--proton-accent) !important;
+}
+
+/* text color #0066cc */
+body[data-page*="ssclash"] [style*="color: #0066cc"],
+body[data-page*="mihomo"] [style*="color: #0066cc"] {
+    color: var(--proton-accent) !important;
+}
+
+/* ── Technical list: description paragraphs — brighter, accent-tinted ── */
+body[data-page*="ssclash"] [style*="border: 2px solid #0066cc"] .cbi-section-descr,
+body[data-page*="mihomo"] [style*="border: 2px solid #0066cc"] .cbi-section-descr {
+    color: rgba(var(--proton-accent-rgb), 0.65) !important;
+}
+
+/* ── Light theme: SSClash pages look fine with their own styles ── */
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: white"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #fff"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #f9f9f9"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #f8f9fa"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: white"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: #fff"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: #f9f9f9"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="color: #1f2937"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="color: #4b5563"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="border: 1px solid #ddd"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="border: 2px solid #ddd"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #e6f3ff"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #e8f5e8"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #fff3cd"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="color: #856404"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="color: #155724"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: #5cb85c"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: #d9534f"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: #f0f8ff"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: #0066cc"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: rgba(0,102,204"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background-color: rgba(0, 102, 204"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: rgba(0,102,204"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="background: rgba(0, 102, 204"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="border: 2px solid #0066cc"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="border-left: 4px solid #0066cc"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="border-color: #0066cc"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="border-color: rgb(0, 102, 204"],
+:root[data-theme="light"] body[data-page*="ssclash"] [style*="color: #0066cc"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: white"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #fff"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #f9f9f9"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #f8f9fa"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background-color: #f9f9f9"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="color: #1f2937"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #e6f3ff"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #e8f5e8"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #fff3cd"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="color: #856404"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="color: #155724"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background-color: #5cb85c"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background-color: #d9534f"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background-color: #f0f8ff"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: #0066cc"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background-color: rgba(0,102,204"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background-color: rgba(0, 102, 204"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: rgba(0,102,204"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="background: rgba(0, 102, 204"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="border: 2px solid #0066cc"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="border-left: 4px solid #0066cc"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="border-color: #0066cc"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="border-color: rgb(0, 102, 204"],
+:root[data-theme="light"] body[data-page*="mihomo"] [style*="color: #0066cc"] {
+    all: revert;
+}
+
+/* ── Ace editor light theme (SSClash / Mihomo config page) ──────────────
+   SSClash hardcodes the tomorrow_night_bright Ace theme (black bg).
+   In light mode we remap it to the Tomorrow Light palette so the editor
+   background matches the rest of the page.
+   ──────────────────────────────────────────────────────────────────── */
+
+/* Base: background + default text */
+:root[data-theme="light"] .ace-tomorrow-night-bright {
+    background-color: #f5f7fa !important;
+    color: #4d4d4c !important;
+}
+
+/* Gutter (line numbers) */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_gutter {
+    background: #eaedf1 !important;
+    color: #888a8c !important;
+}
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_print-margin {
+    background: #d6d9de !important;
+}
+
+/* Cursor */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_cursor {
+    color: #4d4d4c !important;
+}
+
+/* Selection / active line */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_marker-layer .ace_selection {
+    background: rgba(59, 130, 246, 0.22) !important;
+}
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_marker-layer .ace_active-line {
+    background: rgba(0, 0, 0, 0.055) !important;
+}
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_gutter-active-line {
+    background-color: rgba(0, 0, 0, 0.08) !important;
+}
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_marker-layer .ace_selected-word {
+    background: rgba(59, 130, 246, 0.1) !important;
+    border-color: rgba(59, 130, 246, 0.4) !important;
+}
+
+/* Bracket match / highlight */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_marker-layer .ace_bracket {
+    border-color: #aaaaaa !important;
+}
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_marker-layer .ace_highlight {
+    background: rgba(255, 220, 0, 0.18) !important;
+    border-color: #c8b900 !important;
+    box-shadow: inset 0 -1px #c8b900 !important;
+}
+
+/* Invisible characters */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_invisible {
+    color: #c5c8c6 !important;
+}
+
+/* Indent guides */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_indent-guide {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWNgYGBgYHB3d/8HAAOEAXnkT3ERAAAAAElFTkSuQmCC") right repeat-y !important;
+}
+
+/* ── Syntax tokens (Tomorrow Light palette) ── */
+
+/* Keywords, storage, meta */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_keyword,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_meta,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_storage,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_storage.ace_type,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_support.ace_type {
+    color: #8959a8 !important; /* purple */
+}
+
+/* Operators */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_keyword.ace_operator {
+    color: #3e999f !important; /* teal */
+}
+
+/* Numbers, constants, units */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_constant.ace_character,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_constant.ace_language,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_constant.ace_numeric,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_keyword.ace_other.ace_unit,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_support.ace_constant,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_variable.ace_parameter {
+    color: #f5871f !important; /* orange */
+}
+
+/* Other constants */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_constant.ace_other {
+    color: #4d4d4c !important;
+}
+
+/* Functions, variables (generic) */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_entity.ace_name.ace_function,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_support.ace_function {
+    color: #4271ae !important; /* blue */
+}
+
+/* Types / support classes */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_support.ace_class,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_support.ace_type {
+    color: #b58900 !important; /* gold */
+}
+
+/* Strings, headings */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_heading,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_markup.ace_heading,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_string {
+    color: #718c00 !important; /* green */
+}
+
+/* Tags, attribute names, variables, regexp — YAML keys fall here */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_entity.ace_name.ace_tag,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_entity.ace_other.ace_attribute-name,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_meta.ace_tag,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_string.ace_regexp,
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_variable {
+    color: #c82829 !important; /* red */
+}
+
+/* Comments */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_comment {
+    color: #8e908c !important; /* gray */
+}
+
+/* Fold marker */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_fold {
+    background-color: #4271ae !important;
+    border-color: #4d4d4c !important;
+}
+
+/* Invalid */
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_invalid {
+    color: #ffffff !important;
+    background-color: #c82829 !important;
+}
+:root[data-theme="light"] .ace-tomorrow-night-bright .ace_invalid.ace_deprecated {
+    color: #ffffff !important;
+    background-color: #8959a8 !important;
 }

--- a/htdocs/luci-static/proton2025/custom-pages.js
+++ b/htdocs/luci-static/proton2025/custom-pages.js
@@ -1701,3 +1701,287 @@
   });
   buttonObserver.observe(document.body, { childList: true, subtree: true });
 })();
+
+// =====================================================
+// luci-mod-dashboard — fix section inline backgrounds
+// luci-mod-dashboard may assign var(--proton-bg) via
+// inline style. CSS !important handles class-based rules;
+// this handles any remaining inline style overrides.
+// =====================================================
+(function () {
+  "use strict";
+
+  function fixDashboardSectionBackgrounds() {
+    var page = document.body.dataset.page || "";
+    if (page.indexOf("admin-dashboard") !== 0) return;
+
+    var sections = document.querySelectorAll(".cbi-section");
+    for (var i = 0; i < sections.length; i++) {
+      var el = sections[i];
+      var inlineStyle = el.getAttribute("style") || "";
+      // Только если инлайн-стиль явно выставляет var(--proton-bg) без суффикса
+      if (inlineStyle && /--proton-bg\b/.test(inlineStyle) && !/--proton-bg-/.test(inlineStyle)) {
+        el.style.background = "var(--proton-bg-secondary)";
+        el.style.borderColor = "var(--proton-border)";
+      }
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", fixDashboardSectionBackgrounds);
+  } else {
+    fixDashboardSectionBackgrounds();
+  }
+
+  // SPA navigation
+  var dashBgObserver = new MutationObserver(function (mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      if (mutations[i].attributeName === "data-page") {
+        setTimeout(fixDashboardSectionBackgrounds, 100);
+        break;
+      }
+    }
+  });
+  dashBgObserver.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["data-page"],
+  });
+
+  // Watch for dynamically added sections on dashboard
+  var dashContentObserver = new MutationObserver(function () {
+    var page = document.body.dataset.page || "";
+    if (page.indexOf("admin-dashboard") === 0) {
+      fixDashboardSectionBackgrounds();
+    }
+  });
+  dashContentObserver.observe(document.body, { childList: true, subtree: true });
+})();
+
+// =====================================================
+// SSClash / Mihomo inline-style patcher
+//
+// Problem: SSClash mutates element.style.* at runtime (hover, selection).
+// When any property is set via JS, the browser re-serializes the entire
+// CSSStyleDeclaration, normalizing hex colors to rgb() — so
+// "color: #1f2937" becomes "color: rgb(31, 41, 55)" and our CSS
+// [style*="color: #1f2937"] stops matching.
+//
+// Patches are split into two tiers:
+//   ACCENT — applied in both dark and light themes (selection states,
+//             borders that should follow the Proton theme accent color).
+//   DARK   — applied only in dark theme (neutral backgrounds / text).
+// =====================================================
+(function () {
+  "use strict";
+
+  function isSSClashPage() {
+    var page = document.body.dataset.page || "";
+    return page.indexOf("ssclash") !== -1 || page.indexOf("mihomo") !== -1;
+  }
+
+  function isDark() {
+    return document.documentElement.getAttribute("data-theme") !== "light";
+  }
+
+  // ── Tier 1: accent-aware remaps (both themes) ──────────────────────
+
+  // SSClash hardcodes #0066cc as its "selected" border.
+  // Remap to --proton-accent so the theme colour is respected.
+  var BORDER_ACCENT = {
+    "#0066cc":          "var(--proton-accent)",
+    "rgb(0, 102, 204)": "var(--proton-accent)",
+  };
+
+  // SSClash uses #f0f8ff / #e6f3ff as selected-state backgrounds.
+  // Remap to --proton-accent-rgb tints so the accent colour is respected.
+  // setProperty() is used below to store CSS-var expressions safely.
+  var BG_ACCENT = {
+    "#f0f8ff":            "rgba(var(--proton-accent-rgb), 0.10)",
+    "rgb(240, 248, 255)": "rgba(var(--proton-accent-rgb), 0.10)",
+    "#e6f3ff":            "rgba(var(--proton-accent-rgb), 0.08)",
+    "rgb(230, 243, 255)": "rgba(var(--proton-accent-rgb), 0.08)",
+  };
+
+  // ── Tier 2: dark-theme remaps (dark mode only) ─────────────────────
+
+  // White / near-white panels → dark surface
+  var BG_DARK = {
+    "white":              "var(--proton-bg-secondary)",
+    "#fff":               "var(--proton-bg-secondary)",
+    "rgb(255, 255, 255)": "var(--proton-bg-secondary)",
+    "#f9f9f9":            "var(--proton-bg-secondary)",
+    "rgb(249, 249, 249)": "var(--proton-bg-secondary)",
+    "#f8f9fa":            "var(--proton-bg-secondary)",
+    "rgb(248, 249, 250)": "var(--proton-bg-secondary)",
+    "#f8f8f8":            "var(--proton-bg-secondary)",
+    "rgb(248, 248, 248)": "var(--proton-bg-secondary)",
+    // green-tint: auto-detected LAN bridge, hover on checked interface
+    "#f8fff8":            "rgba(40, 167, 69, 0.13)",
+    "rgb(248, 255, 248)": "rgba(40, 167, 69, 0.13)",
+    "#e8f5e8":            "rgba(40, 167, 69, 0.15)",
+    "rgb(232, 245, 232)": "rgba(40, 167, 69, 0.15)",
+    "#f0fff0":            "rgba(40, 167, 69, 0.13)",
+    "rgb(240, 255, 240)": "rgba(40, 167, 69, 0.13)",
+    // amber-tint: warning panels
+    "#fff3cd":            "rgba(255, 193, 7, 0.14)",
+    "rgb(255, 243, 205)": "rgba(255, 193, 7, 0.14)",
+  };
+
+  // Dark text → readable in dark theme
+  var COLOR_DARK = {
+    "rgb(31, 41, 55)":    "var(--proton-fg)",
+    "rgb(55, 65, 81)":    "var(--proton-fg)",
+    "rgb(75, 85, 99)":    "var(--proton-muted)",
+    "rgb(107, 114, 128)": "var(--proton-muted)",
+    "rgb(133, 100, 4)":   "#e9c46a",
+    "rgb(21, 87, 36)":    "#6fcf97",
+  };
+
+  // Neutral borders → Proton border token (dark-mode only)
+  var BORDER_DARK = {
+    "rgb(221, 221, 221)": "var(--proton-border)",
+    "rgb(204, 204, 204)": "var(--proton-border)",
+  };
+
+  // ── Patch a single element ─────────────────────────────────────────
+
+  function patchEl(el) {
+    if (!el || !el.style) return;
+    var s = el.style;
+
+    // Tier 1: accent border (both themes)
+    var bc = s.borderColor;
+    if (bc && BORDER_ACCENT[bc] !== undefined) {
+      s.setProperty("border-color", BORDER_ACCENT[bc]);
+    }
+
+    // Tier 1: accent background tint (both themes)
+    var bg = s.backgroundColor;
+    if (bg && BG_ACCENT[bg] !== undefined) {
+      s.setProperty("background-color", BG_ACCENT[bg]);
+      bg = null; // skip BG_DARK check for this element
+    }
+
+    if (!isDark()) return;
+
+    // Tier 2: neutral background → dark surface
+    if (bg === null) bg = s.backgroundColor;
+    if (bg && BG_DARK[bg] !== undefined) {
+      s.backgroundColor = BG_DARK[bg];
+    }
+
+    // Tier 2: text colour
+    var col = s.color;
+    if (col && COLOR_DARK[col] !== undefined) {
+      s.color = COLOR_DARK[col];
+    }
+
+    // Tier 2: neutral border
+    bc = s.borderColor;
+    if (bc && BORDER_DARK[bc] !== undefined) {
+      s.borderColor = BORDER_DARK[bc];
+    }
+
+    var blc = s.borderLeftColor;
+    if (blc && BORDER_DARK[blc] !== undefined) {
+      s.borderLeftColor = BORDER_DARK[blc];
+    }
+  }
+
+  // ── Patch all styled elements inside maincontent ───────────────────
+
+  function patchAll() {
+    var root = document.getElementById("maincontent") || document.body;
+    var els = root.querySelectorAll("[style]");
+    for (var i = 0; i < els.length; i++) {
+      patchEl(els[i]);
+    }
+  }
+
+  // ── MutationObserver setup ─────────────────────────────────────────
+
+  var styleObs = null;
+
+  function startObs() {
+    if (styleObs) return;
+    var root = document.getElementById("maincontent") || document.body;
+    styleObs = new MutationObserver(function (mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        var m = mutations[i];
+        if (m.type === "attributes") {
+          patchEl(m.target);
+        } else if (m.type === "childList") {
+          for (var j = 0; j < m.addedNodes.length; j++) {
+            var node = m.addedNodes[j];
+            if (node.nodeType !== 1) continue;
+            patchEl(node);
+            var ch = node.querySelectorAll("[style]");
+            for (var k = 0; k < ch.length; k++) patchEl(ch[k]);
+          }
+        }
+      }
+    });
+    styleObs.observe(root, {
+      attributes: true,
+      attributeFilter: ["style"],
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  function stopObs() {
+    if (styleObs) { styleObs.disconnect(); styleObs = null; }
+  }
+
+  function onPageChange() {
+    if (isSSClashPage()) {
+      startObs();
+      setTimeout(patchAll, 100);
+    } else {
+      stopObs();
+    }
+  }
+
+  function init() {
+    if (!isSSClashPage()) return;
+    startObs();
+    patchAll();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+  window.addEventListener("load", function () {
+    if (isSSClashPage()) { patchAll(); }
+  });
+
+  // SPA navigation (data-page changes)
+  var ssNavObs = new MutationObserver(function (mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      if (mutations[i].attributeName === "data-page") {
+        setTimeout(onPageChange, 50);
+        return;
+      }
+    }
+  });
+  ssNavObs.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["data-page"],
+  });
+
+  // Theme toggle (dark ↔ light): re-patch so accent/dark tiers both apply
+  var ssThemeObs = new MutationObserver(function (mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      if (mutations[i].attributeName === "data-theme") {
+        if (isSSClashPage()) setTimeout(patchAll, 50);
+        return;
+      }
+    }
+  });
+  ssThemeObs.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+})();

--- a/htdocs/luci-static/proton2025/login-animation-settings.js
+++ b/htdocs/luci-static/proton2025/login-animation-settings.js
@@ -7,22 +7,6 @@
 
     var STORAGE_KEY = "proton-login-animation";
 
-    var OPTIONS = [
-        ["off", "Off"],
-        ["particles", "Classic Particles"],
-        ["constellation", "Constellation"],
-        ["plexus", "Plexus / Neural"],
-        ["breathing", "Breathing Particles"],
-        ["gravity", "Gravity Hover"],
-        ["lowpoly", "Low Poly Mesh"],
-        ["dataflow", "Data Flow"],
-        ["flowfield", "Flow Field"],
-        ["circuit", "Circuit Board"],
-        ["packetpulses", "Packet Pulses"],
-        ["hex", "Hex Grid"],
-        ["underwater", "Underwater Depths"]
-    ];
-
     function isRu() {
         var lang = (document.documentElement.lang || document.body.dataset.lang || "").toLowerCase();
         return lang.indexOf("ru") === 0;
@@ -31,6 +15,22 @@
     function tr(en, ru) {
         return isRu() ? ru : en;
     }
+
+    var OPTIONS = [
+        ["off", tr("Off", "Выкл")],
+        ["particles", tr("Classic Particles", "Классические частицы")],
+        ["constellation", tr("Constellation", "Созвездие")],
+        ["plexus", tr("Plexus / Neural", "Плекс / Нейронный")],
+        ["breathing", tr("Breathing Particles", "Дышащие частицы")],
+        ["gravity", tr("Gravity Hover", "Гравитация")],
+        ["lowpoly", tr("Low Poly Mesh", "Низкополигональная сетка")],
+        ["dataflow", tr("Data Flow", "Поток данных")],
+        ["flowfield", tr("Flow Field", "Поле течений")],
+        ["circuit", tr("Circuit Board", "Плата схем")],
+        ["packetpulses", tr("Packet Pulses", "Пакетные импульсы")],
+        ["hex", tr("Hex Grid", "Шестиугольная сетка")],
+        ["underwater", tr("Underwater Depths", "Подводные глубины")]
+    ];
 
     function getTitleText(row) {
         var title = row.querySelector(".cbi-value-title, label, .control-label");

--- a/htdocs/luci-static/proton2025/login-bg.css
+++ b/htdocs/luci-static/proton2025/login-bg.css
@@ -114,16 +114,16 @@ body.login-page .login-logo {
 /* Light mode support for animated login page */
 :root[data-theme="light"] body.login-page {
   background:
-    radial-gradient(circle at 20% 15%, rgba(47, 116, 208, 0.18), transparent 34%),
-    radial-gradient(circle at 80% 80%, rgba(47, 116, 208, 0.12), transparent 38%),
+    radial-gradient(circle at 20% 15%, rgba(var(--proton-accent-rgb, 47, 116, 208), 0.18), transparent 34%),
+    radial-gradient(circle at 80% 80%, rgba(var(--proton-accent-rgb, 47, 116, 208), 0.12), transparent 38%),
     linear-gradient(135deg, #f4f7fb, #e9f0f9 55%, #dfe9f6) !important;
   color: #152033 !important;
 }
 
 :root[data-theme="light"] #particles-js {
   background:
-    radial-gradient(circle at 20% 15%, rgba(47, 116, 208, 0.18), transparent 34%),
-    radial-gradient(circle at 80% 80%, rgba(47, 116, 208, 0.12), transparent 38%),
+    radial-gradient(circle at 20% 15%, rgba(var(--proton-accent-rgb, 47, 116, 208), 0.18), transparent 34%),
+    radial-gradient(circle at 80% 80%, rgba(var(--proton-accent-rgb, 47, 116, 208), 0.12), transparent 38%),
     linear-gradient(135deg, #f4f7fb, #e9f0f9 55%, #dfe9f6) !important;
 }
 
@@ -134,11 +134,11 @@ body.login-page .login-logo {
 
 :root[data-theme="light"] .login-card {
   background: rgba(255, 255, 255, 0.82) !important;
-  border-color: rgba(57, 116, 210, 0.18) !important;
+  border-color: rgba(var(--proton-accent-rgb, 47, 116, 208), 0.18) !important;
   color: #152033 !important;
   box-shadow:
-    0 18px 55px rgba(42, 70, 120, 0.16),
-    0 0 32px rgba(47, 116, 208, 0.20) !important;
+    0 18px 55px rgba(0, 0, 0, 0.16),
+    0 0 32px var(--proton-accent-glow, rgba(47, 116, 208, 0.20)) !important;
 }
 
 :root[data-theme="light"] .login-card,
@@ -161,7 +161,7 @@ body.login-page .login-logo {
 :root[data-theme="light"] .login-form textarea {
   background: rgba(255, 255, 255, 0.76) !important;
   color: #152033 !important;
-  border-color: rgba(47, 116, 208, 0.22) !important;
+  border-color: rgba(var(--proton-accent-rgb, 47, 116, 208), 0.22) !important;
 }
 
 :root[data-theme="light"] .login-form input::placeholder {
@@ -171,14 +171,14 @@ body.login-page .login-logo {
 :root[data-theme="light"] .login-form button,
 :root[data-theme="light"] .login-form input[type="submit"],
 :root[data-theme="light"] .login-form .btn {
-  background: linear-gradient(135deg, #3d86e8, #2f74d0) !important;
+  background: linear-gradient(135deg, var(--proton-accent, #3d86e8), var(--proton-accent-hover, #2f74d0)) !important;
   color: #ffffff !important;
-  border-color: rgba(47, 116, 208, 0.28) !important;
-  box-shadow: 0 10px 26px rgba(47, 116, 208, 0.24) !important;
+  border-color: transparent !important;
+  box-shadow: 0 10px 26px var(--proton-accent-glow, rgba(47, 116, 208, 0.24)) !important;
 }
 
 :root[data-theme="light"] a {
-  color: #2f74d0 !important;
+  color: var(--proton-accent, #2f74d0) !important;
 }
 
 /* Light mode input contrast fix */
@@ -188,10 +188,10 @@ body.login-page .login-logo {
   background-image: none !important;
   color: #152033 !important;
   -webkit-text-fill-color: #152033 !important;
-  border: 1px solid rgba(47, 116, 208, 0.28) !important;
+  border: 1px solid rgba(var(--proton-accent-rgb, 47, 116, 208), 0.28) !important;
   box-shadow:
-    inset 0 1px 2px rgba(42, 70, 120, 0.06),
-    0 0 0 1px rgba(47, 116, 208, 0.04) !important;
+    inset 0 1px 2px rgba(0, 0, 0, 0.06),
+    0 0 0 1px rgba(var(--proton-accent-rgb, 47, 116, 208), 0.04) !important;
 }
 
 :root[data-theme="light"] body.login-page .login-form input[type="text"]::placeholder,
@@ -205,11 +205,11 @@ body.login-page .login-logo {
   background-color: #ffffff !important;
   color: #152033 !important;
   -webkit-text-fill-color: #152033 !important;
-  border-color: rgba(47, 116, 208, 0.56) !important;
+  border-color: rgba(var(--proton-accent-rgb, 47, 116, 208), 0.56) !important;
   box-shadow:
-    0 0 0 1px rgba(47, 116, 208, 0.20),
-    0 0 0 4px rgba(47, 116, 208, 0.10),
-    0 8px 22px rgba(42, 70, 120, 0.10) !important;
+    0 0 0 1px rgba(var(--proton-accent-rgb, 47, 116, 208), 0.20),
+    0 0 0 4px rgba(var(--proton-accent-rgb, 47, 116, 208), 0.10),
+    0 8px 22px rgba(var(--proton-accent-rgb, 47, 116, 208), 0.10) !important;
 }
 
 :root[data-theme="light"] body.login-page .login-form input:-webkit-autofill,
@@ -217,5 +217,5 @@ body.login-page .login-logo {
 :root[data-theme="light"] body.login-page .login-form input:-webkit-autofill:focus {
   -webkit-text-fill-color: #152033 !important;
   box-shadow: 0 0 0 1000px #ffffff inset !important;
-  border: 1px solid rgba(47, 116, 208, 0.28) !important;
+  border: 1px solid rgba(var(--proton-accent-rgb, 47, 116, 208), 0.28) !important;
 }

--- a/htdocs/luci-static/proton2025/login-particles.js
+++ b/htdocs/luci-static/proton2025/login-particles.js
@@ -52,6 +52,9 @@
     }
 
     function rgba(c, a) {
+        if (document.documentElement.getAttribute("data-theme") === "light") {
+            a = Math.min(1, a * 2.25);
+        }
         return "rgba(" + Math.round(c.r) + "," + Math.round(c.g) + "," + Math.round(c.b) + "," + a + ")";
     }
 

--- a/htdocs/luci-static/proton2025/services-widget.js
+++ b/htdocs/luci-static/proton2025/services-widget.js
@@ -93,6 +93,7 @@
         // AdBlock / DNS фильтрация
         adblock: { category: "adblock", icon: "🚫" },
         adguardhome: { category: "adblock", icon: "🛡️" },
+        smartdns: { category: "adblock", icon: "🛡️" },
         pihole: { category: "adblock", icon: "🕳️" },
 
         // Система

--- a/htdocs/luci-static/proton2025/settings-sync.js
+++ b/htdocs/luci-static/proton2025/settings-sync.js
@@ -303,7 +303,7 @@
     // Reset all settings to defaults
     resetToDefaults: async function () {
       const defaults = {
-        "proton-theme-mode": "dark",
+        "proton-theme-mode": "auto",
         "proton-accent-color": "blue",
         "proton-zoom": "100",
         "proton-transparency": "true",

--- a/htdocs/luci-static/proton2025/translations.js
+++ b/htdocs/luci-static/proton2025/translations.js
@@ -471,8 +471,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Proton2025 主题设置",
     "Theme Mode": "主题模式",
+    Auto: "自动",
     Dark: "深色",
     Light: "浅色",
+    "Choose light, dark, or follow system theme":
+      "选择浅色、深色主题或跟随系统设置",
     "Choose light or dark theme": "选择浅色或深色主题",
     "Accent Color": "强调色",
     "Choose theme accent color": "选择主题强调色",
@@ -789,8 +792,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Proton2025 Theme-Einstellungen",
     "Theme Mode": "Theme-Modus",
+    Auto: "Auto",
     Dark: "Dunkel",
     Light: "Hell",
+    "Choose light, dark, or follow system theme":
+      "Helles, dunkles Theme oder Systemeinstellung wählen",
     "Choose light or dark theme": "Helles oder dunkles Theme wählen",
     "Accent Color": "Akzentfarbe",
     "Choose theme accent color": "Theme-Akzentfarbe wählen",
@@ -1109,8 +1115,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Налаштування теми Proton2025",
     "Theme Mode": "Режим теми",
+    Auto: "Авто",
     Dark: "Темний",
     Light: "Світлий",
+    "Choose light, dark, or follow system theme":
+      "Виберіть світлу, темну тему або слідування системній темі",
     "Choose light or dark theme": "Виберіть світлу або темну тему",
     "Accent Color": "Акцентний колір",
     "Choose theme accent color": "Виберіть акцентний колір теми",
@@ -1431,8 +1440,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Configuración del Tema Proton2025",
     "Theme Mode": "Modo del Tema",
+    Auto: "Auto",
     Dark: "Oscuro",
     Light: "Claro",
+    "Choose light, dark, or follow system theme":
+      "Elegir tema claro, oscuro o seguir el tema del sistema",
     "Choose light or dark theme": "Elegir tema claro u oscuro",
     "Accent Color": "Color de Acento",
     "Choose theme accent color": "Elegir color de acento del tema",
@@ -1755,8 +1767,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Configurações do Tema Proton2025",
     "Theme Mode": "Modo do Tema",
+    Auto: "Auto",
     Dark: "Escuro",
     Light: "Claro",
+    "Choose light, dark, or follow system theme":
+      "Escolher tema claro, escuro ou seguir o tema do sistema",
     "Choose light or dark theme": "Escolher tema claro ou escuro",
     "Accent Color": "Cor de Destaque",
     "Choose theme accent color": "Escolher cor de destaque do tema",
@@ -2077,8 +2092,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Ustawienia Motywu Proton2025",
     "Theme Mode": "Tryb Motywu",
+    Auto: "Auto",
     Dark: "Ciemny",
     Light: "Jasny",
+    "Choose light, dark, or follow system theme":
+      "Wybierz jasny, ciemny motyw lub podążanie za motywem systemowym",
     "Choose light or dark theme": "Wybierz jasny lub ciemny motyw",
     "Accent Color": "Kolor Akcentu",
     "Choose theme accent color": "Wybierz kolor akcentu motywu",
@@ -2400,8 +2418,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Paramètres du Thème Proton2025",
     "Theme Mode": "Mode du Thème",
+    Auto: "Auto",
     Dark: "Sombre",
     Light: "Clair",
+    "Choose light, dark, or follow system theme":
+      "Choisir un thème clair, sombre ou suivre le thème du système",
     "Choose light or dark theme": "Choisir un thème clair ou sombre",
     "Accent Color": "Couleur d'Accent",
     "Choose theme accent color": "Choisir la couleur d'accent du thème",
@@ -2724,8 +2745,11 @@ window.ProtonTranslations = {
     // Theme Settings
     "Proton2025 Theme Settings": "Impostazioni Tema Proton2025",
     "Theme Mode": "Modalità Tema",
+    Auto: "Auto",
     Dark: "Scuro",
     Light: "Chiaro",
+    "Choose light, dark, or follow system theme":
+      "Scegli tema chiaro, scuro o segui il tema di sistema",
     "Choose light or dark theme": "Scegli tema chiaro o scuro",
     "Accent Color": "Colore Accento",
     "Choose theme accent color": "Scegli il colore accento del tema",

--- a/htdocs/luci-static/resources/menu-proton2025.js
+++ b/htdocs/luci-static/resources/menu-proton2025.js
@@ -120,9 +120,9 @@ return baseclass.extend({
     const storedThemeMode = localStorage.getItem("proton-theme-mode");
     const settings = {
       themeMode:
-        storedThemeMode === "light" || storedThemeMode === "auto"
+        storedThemeMode === "light" || storedThemeMode === "dark"
           ? storedThemeMode
-          : "dark",
+          : "auto",
       accentColor: localStorage.getItem("proton-accent-color") || "blue",
       borderRadius: localStorage.getItem("proton-border-radius") || "default",
       zoom: localStorage.getItem("proton-zoom") || defaultZoom,
@@ -2005,9 +2005,9 @@ return baseclass.extend({
       const storedThemeMode = localStorage.getItem("proton-theme-mode");
       const settings = {
         themeMode:
-          storedThemeMode === "light" || storedThemeMode === "auto"
+          storedThemeMode === "light" || storedThemeMode === "dark"
             ? storedThemeMode
-            : "dark",
+            : "auto",
         accentColor: localStorage.getItem("proton-accent-color") || "blue",
         borderRadius: localStorage.getItem("proton-border-radius") || "default",
         zoom: parseInt(localStorage.getItem("proton-zoom") || defaultZoom),
@@ -2045,7 +2045,7 @@ return baseclass.extend({
                 }>${t("Auto")} (${t("System")})</option>
                 <option value="dark" ${
                   settings.themeMode === "dark" ? "selected" : ""
-                }>${t("Dark")} (${t("Default")})</option>
+                }>${t("Dark")}</option>
                 <option value="light" ${
                   settings.themeMode === "light" ? "selected" : ""
                 }>${t("Light")}</option>
@@ -2150,7 +2150,7 @@ return baseclass.extend({
               <div id="proton-page-width-slider" style="display: ${settings.pageWidth > 0 ? "flex" : "none"}; align-items: center; gap: 12px; margin-top: 8px;">
                 <button type="button" id="proton-page-width-minus" class="cbi-button" style="padding: 0.4rem 0.8rem; min-width: auto;">−</button>
                 <input type="range" id="proton-page-width-range" min="50" max="100" step="5" value="${
-                  settings.pageWidth > 0 ? settings.pageWidth : 75
+                  settings.pageWidth > 0 ? settings.pageWidth : 80
                 }" style="flex: 1; accent-color: var(--proton-accent);">
                 <button type="button" id="proton-page-width-plus" class="cbi-button" style="padding: 0.4rem 0.8rem; min-width: auto;">+</button>
               </div>
@@ -2404,12 +2404,16 @@ return baseclass.extend({
         const mode = e.target.value;
         localStorage.setItem("proton-theme-mode", mode);
         this.applyThemeMode(mode);
+        if (zoomRange) updateSliderFill(zoomRange);
+        if (pageWidthRange) updateSliderFill(pageWidthRange);
       });
 
       accentSelect?.addEventListener("change", (e) => {
         const color = e.target.value;
         localStorage.setItem("proton-accent-color", color);
         this.applyAccentColor(color);
+        if (zoomRange) updateSliderFill(zoomRange);
+        if (pageWidthRange) updateSliderFill(pageWidthRange);
       });
 
       radiusSelect?.addEventListener("change", (e) => {
@@ -2876,7 +2880,7 @@ return baseclass.extend({
           } else {
             // Fallback if sync module not loaded
             const defaults = {
-              "proton-theme-mode": "dark",
+              "proton-theme-mode": "auto",
               "proton-accent-color": "blue",
               "proton-zoom": "100",
               "proton-transparency": "true",
@@ -3025,7 +3029,7 @@ return baseclass.extend({
     );
 
     const handleThemeModeChange = () => {
-      const storedMode = localStorage.getItem("proton-theme-mode") || "dark";
+      const storedMode = localStorage.getItem("proton-theme-mode") || "auto";
       if (storedMode === "auto") {
         this.applyThemeMode("auto");
       }
@@ -3177,7 +3181,7 @@ return baseclass.extend({
     if (window.innerWidth < 800) {
       document.documentElement.style.setProperty(
         "--proton-page-max-width",
-        "990px",
+        "80%",
       );
       return;
     }
@@ -3189,7 +3193,7 @@ return baseclass.extend({
     } else {
       document.documentElement.style.setProperty(
         "--proton-page-max-width",
-        "990px",
+        "80%",
       );
     }
   },

--- a/root/etc/config/proton2025
+++ b/root/etc/config/proton2025
@@ -5,7 +5,7 @@
 # This file stores theme settings that sync across browsers
 
 config theme 'settings'
-option mode 'dark'
+option mode 'auto'
 option accent 'blue'
 option zoom '100'
 option transparency '1'

--- a/root/etc/uci-defaults/30_luci-theme-proton2025
+++ b/root/etc/uci-defaults/30_luci-theme-proton2025
@@ -37,7 +37,7 @@ set_proton_default() {
 	fi
 }
 
-set_proton_default mode 'dark'
+set_proton_default mode 'auto'
 set_proton_default accent 'blue'
 set_proton_default zoom '100'
 set_proton_default transparency '1'

--- a/root/usr/share/rpcd/ucode/luci.proton-settings
+++ b/root/usr/share/rpcd/ucode/luci.proton-settings
@@ -13,7 +13,7 @@ const SECTION_NAME = 'settings';
 
 // Valid options and their defaults
 const VALID_OPTIONS = {
-	mode: { default: 'dark', values: ['dark', 'light', 'auto'] },
+	mode: { default: 'auto', values: ['dark', 'light', 'auto'] },
 	accent: { default: 'blue', values: ['default', 'blue', 'purple', 'green', 'orange', 'red'] },
 	zoom: { default: '100', min: 50, max: 150 },
 	transparency: { default: '1', values: ['0', '1'] },

--- a/ucode/template/themes/proton2025/header.ut
+++ b/ucode/template/themes/proton2025/header.ut
@@ -56,7 +56,7 @@
 	}
 
 	// Применяем тему ДО отрисовки страницы, чтобы избежать мерцания
-	var storedThemeMode = localStorage.getItem('proton-theme-mode') || 'dark';
+	var storedThemeMode = localStorage.getItem('proton-theme-mode') || 'auto';
 	var themeMode = resolveThemeMode(storedThemeMode);
 	if (themeMode === 'light') {
 		document.documentElement.setAttribute('data-theme', 'light');

--- a/ucode/template/themes/proton2025/sysauth.ut
+++ b/ucode/template/themes/proton2025/sysauth.ut
@@ -85,7 +85,7 @@
      }
 
      // Theme mode (dark/light/auto)
-     var themeMode = resolveThemeMode(localStorage.getItem('proton-theme-mode') || 'dark');
+     var themeMode = resolveThemeMode(localStorage.getItem('proton-theme-mode') || 'auto');
      if (themeMode === 'light') {
              document.documentElement.setAttribute('data-theme', 'light');
              document.documentElement.setAttribute('data-darkmode', 'false');
@@ -112,21 +112,42 @@
 	// Accent color
 	var a = localStorage.getItem('proton-accent-color') || 'blue';
 	var c = {
-		default: { accent: '#4b5563', hover: '#374151', glow: 'rgba(75, 85, 99, 0.22)' },
-		blue:    { accent: '#5e9eff', hover: '#7db2ff', glow: 'rgba(94, 158, 255, 0.18)' },
-		purple:  { accent: '#a78bfa', hover: '#c3b4ff', glow: 'rgba(167, 139, 250, 0.22)' },
-		green:   { accent: '#34d399', hover: '#2fb885', glow: 'rgba(52, 211, 153, 0.18)' },
-		orange:  { accent: '#fb923c', hover: '#f47c1f', glow: 'rgba(251, 146, 60, 0.20)' },
-		red:     { accent: '#f87171', hover: '#f04c4c', glow: 'rgba(248, 113, 113, 0.20)' }
+		default: { accent: '#4b5563', hover: '#374151', glow: 'rgba(75, 85, 99, 0.22)', rgb: '75, 85, 99' },
+		blue:    { accent: '#5e9eff', hover: '#7db2ff', glow: 'rgba(94, 158, 255, 0.18)', rgb: '94, 158, 255' },
+		purple:  { accent: '#a78bfa', hover: '#c3b4ff', glow: 'rgba(167, 139, 250, 0.22)', rgb: '167, 139, 250' },
+		green:   { accent: '#34d399', hover: '#2fb885', glow: 'rgba(52, 211, 153, 0.18)', rgb: '52, 211, 153' },
+		orange:  { accent: '#fb923c', hover: '#f47c1f', glow: 'rgba(251, 146, 60, 0.20)', rgb: '251, 146, 60' },
+		red:     { accent: '#f87171', hover: '#f04c4c', glow: 'rgba(248, 113, 113, 0.20)', rgb: '248, 113, 113' }
 	};
 	if (c[a]) {
 		document.documentElement.style.setProperty('--proton-accent', c[a].accent);
 		document.documentElement.style.setProperty('--proton-accent-hover', c[a].hover);
 		document.documentElement.style.setProperty('--proton-accent-glow', c[a].glow);
+		document.documentElement.style.setProperty('--proton-accent-rgb', c[a].rgb);
 	}
 	
 	// Animations
 	if (localStorage.getItem('proton-animations') === 'false') document.documentElement.classList.add('proton-no-animations');
+
+	// Background color (set before cascade.css loads to avoid a flash)
+	var bgSolid = themeMode === 'light' ? '#ffffff' : '#0f1419';
+	document.documentElement.style.setProperty('background-color', bgSolid);
+
+	// Live-follow OS theme changes while in 'auto' mode
+	if ((localStorage.getItem('proton-theme-mode') || 'auto') === 'auto' && window.matchMedia) {
+		var mq = window.matchMedia('(prefers-color-scheme: dark)');
+		var applyOsTheme = function (dark) {
+			var theme = dark ? 'dark' : 'light';
+			document.documentElement.setAttribute('data-theme', theme);
+			document.documentElement.setAttribute('data-darkmode', dark ? 'true' : 'false');
+			document.documentElement.style.setProperty('background-color', dark ? '#0f1419' : '#ffffff');
+		};
+		if (typeof mq.addEventListener === 'function') {
+			mq.addEventListener('change', function (ev) { applyOsTheme(ev.matches); });
+		} else if (typeof mq.addListener === 'function') {
+			mq.addListener(function (ev) { applyOsTheme(ev.matches); });
+		}
+	}
 
 	// Login page means a new auth session is starting soon, so restore any
 	// alerts that were only dismissed for the previous authenticated session.


### PR DESCRIPTION
Режим темы "Авто" (по умолчанию вместо "Тёмная")

- Тема теперь по умолчанию следует системным настройкам (auto), а не всегда тёмная
- Изменено во всех точках: settings-sync.js, menu-proton2025.js, конфиг proton2025, 30_luci-theme-proton2025, rpcd luci.proton-settings, header.ut, sysauth.ut
- В menu-proton2025.js убрана устаревшая пометка "(По умолчанию)" у пункта "Тёмная" (теперь по умолчанию "Авто")
- В sysauth.ut (страница входа) добавлено живое отслеживание смены системной темы через matchMedia — если включён режим "авто", страница входа переключается между тёмной/светлой темой на лету, без перезагрузки

Страница входа (анимации и оформление)

- login-particles.js: частицы становятся ярче (~×2.25 альфа-канал) в светлой теме — иначе они были еле заметны на светлом фоне
- login-bg.css: все жёстко заданные синие цвета заменены на CSS-переменные акцента (--proton-accent, --proton-accent-rgb, --proton-accent-glow) — теперь страница входа следует выбранному пользователем акцентному цвету
- sysauth.ut: добавлена переменная --proton-accent-rgb для вычисления rgba()-цветов, добавлена установка фонового цвета до загрузки cascade.css (устраняет "мигание" при загрузке)
- (Текущая версия login-animation-settings.js оставлена без изменений — она уже более продвинутая, чем в PR: больше режимов анимации, локализация и т.д.)
- Перевод названий анимаций

Настройки темы / UI

- Слайдер ширины страницы: значение по умолчанию изменено с 75% на 80%, как и резервное значение --proton-page-max-width (с 990px на 80%)
- Полоса заполнения слайдеров (zoom, ширина страницы) теперь обновляется при смене режима темы и акцентного цвета — раньше цвет заливки мог "застревать"

🛡 Виджет сервисов

- Добавлена поддержка SmartDNS в категории блокировки рекламы (smartdns: { category: "adblock", icon: "🛡️" })

Переводы

- Добавлены переводы строк "Авто" и описания режима темы ("Выберите светлую, тёмную тему или следование системной теме") для языков: zh, de, uk, es, pt, pl, fr, it (для ru они уже были)

Уже было сделано ранее в этой ветке (для контекста PR)

- cascade.css: множество правок — компактные таблицы, фиксы переполнения, тёмная тема для SSClash/Mihomo, светлая палитра для Ace-редактора, фиксы дашборда
- custom-pages.js: патчер инлайн-стилей для дашборда LuCI и SSClash/Mihomo