### PR TITLE
Keep login page fullscreen when UI zoom changes

### DIFF
--- a/htdocs/luci-static/proton2025/login-bg.css
+++ b/htdocs/luci-static/proton2025/login-bg.css
@@ -219,3 +219,20 @@ body.login-page .login-logo {
   box-shadow: 0 0 0 1000px #ffffff inset !important;
   border: 1px solid rgba(var(--proton-accent-rgb, 47, 116, 208), 0.28) !important;
 }
+
+/* Login page: keep fullscreen background, scale login UI,
+   and compensate animation layer size so no empty bands appear */
+body.login-page #particles-js {
+    position: fixed !important;
+    left: 50% !important;
+    top: 50% !important;
+    width: calc(100vw / var(--proton-login-scale, 1)) !important;
+    height: calc(100vh / var(--proton-login-scale, 1)) !important;
+    transform: translate(-50%, -50%) scale(var(--proton-login-scale, 1)) !important;
+    transform-origin: center center !important;
+}
+
+body.login-page .login-card {
+    transform: scale(var(--proton-login-scale, 1)) !important;
+    transform-origin: center center !important;
+}

--- a/ucode/template/themes/proton2025/sysauth.ut
+++ b/ucode/template/themes/proton2025/sysauth.ut
@@ -97,8 +97,21 @@
 	
 	// Zoom
 	var defaultZoom = '100';
-	var z = localStorage.getItem('proton-zoom') || defaultZoom;
-	document.documentElement.style.zoom = z / 100;
+	var z = parseInt(localStorage.getItem('proton-zoom') || defaultZoom, 10);
+
+	if (isNaN(z)) {
+	    z = 100;
+	}
+
+	z = Math.max(75, Math.min(150, z));
+
+	// Keep the login page fullscreen. Apply UI zoom only to the login content.
+	document.documentElement.style.zoom = '';
+	document.documentElement.style.setProperty('--proton-login-scale', z / 100);
+
+	if (document.body) {
+	    document.body.style.zoom = '';
+	}
 	
 	// Transparency
 	var t = localStorage.getItem('proton-transparency');


### PR DESCRIPTION
Исправление отображения страницы авторизации при изменённом масштабе интерфейса

Этот PR исправляет проблему со страницей авторизации Proton2025, которая проявлялась при значении масштаба интерфейса ниже 100%.

Раньше сохранённый параметр масштаба применялся напрямую ко всему `html`-документу. Из-за этого при значениях вроде 90% вся fullscreen-страница авторизации уменьшалась целиком, и внизу экрана могла появляться пустая область.

Теперь сама страница авторизации остаётся полноэкранной, а масштаб интерфейса применяется отдельно к карточке входа и слою анимации.

Локально проверено на значениях масштаба 75%, 80%, 85%, 90%, 95% и 100%.

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

This PR fixes the login page layout when the Proton2025 UI zoom setting is below 100%.

Previously, the login page applied the saved UI zoom directly to the whole `html` document. Because of that, with values like 90%, the entire fullscreen login page was scaled down and an empty area could appear at the bottom of the viewport.

This change keeps the login page itself fullscreen and applies the zoom separately to the login card and animation layer.

Tested locally with 75%, 80%, 85%, 90%, 95% and 100% zoom values.