### PR TITLE
Fix modal table overflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             sdk_url: https://downloads.openwrt.org/releases/23.05.5/targets/x86/64/openwrt-sdk-23.05.5-x86-64_gcc-12.3.0_musl.Linux-x86_64.tar.xz
           - package_format: apk
             artifact_name: luci-theme-proton2025-apk
-            sdk_url: https://downloads.openwrt.org/snapshots/targets/x86/64/openwrt-sdk-x86-64_gcc-14.3.0_musl.Linux-x86_64.tar.zst
+            sdk_url: https://downloads.openwrt.org/snapshots/targets/x86/64/openwrt-sdk-x86-64_gcc-14.4.0_musl.Linux-x86_64.tar.zst
 
     steps:
       - name: Checkout

--- a/htdocs/luci-static/proton2025/cascade.css
+++ b/htdocs/luci-static/proton2025/cascade.css
@@ -14478,3 +14478,50 @@ body[data-page="admin-status-overview"] .cbi-section>div>div[style*="display:gri
     border: none;
     border-radius: var(--proton-radius-sm);
 }
+
+/* Widen modal dialogs containing LuCI CBI tables, e.g. WireGuard peer lists */
+.modal:has(.cbi-section-table),
+.modal:has(.table) {
+  width: min(1180px, calc(100vw - 48px)) !important;
+  max-width: calc(100vw - 48px) !important;
+}
+
+/* Let wide table content use the enlarged dialog instead of leaking outside */
+.modal:has(.cbi-section-table) .cbi-section,
+.modal:has(.table) .cbi-section {
+  max-width: 100%;
+  overflow: visible;
+}
+
+/* On smaller screens, keep table scroll inside the modal */
+.modal:has(.cbi-section-table) .cbi-section-node,
+.modal:has(.table) .cbi-section-node,
+.modal:has(.cbi-section-table) .table,
+.modal:has(.table) .table {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+/* Keep row action buttons on one line */
+.modal .cbi-section-actions,
+.modal .td.cbi-section-actions,
+.modal td.cbi-section-actions {
+  white-space: nowrap;
+}
+
+/* Avoid oversized action buttons stretching modal rows */
+.modal .cbi-section-actions .cbi-button,
+.modal .td.cbi-section-actions .cbi-button,
+.modal td.cbi-section-actions .cbi-button {
+  margin-left: 6px;
+}
+
+/* Mobile fallback: use almost full viewport width */
+@media screen and (max-width: 900px) {
+  .modal:has(.cbi-section-table),
+  .modal:has(.table) {
+    width: calc(100vw - 24px) !important;
+    max-width: calc(100vw - 24px) !important;
+  }
+}


### PR DESCRIPTION
## 🇷🇺

Исправлено некорректное отображение широких LuCI CBI-таблиц внутри модальных окон.

Проблема проявлялась, например, на странице:

`Сеть → Интерфейсы → изменить WireGuard/AmneziaWG-интерфейс → Равноправные узлы`

Вкладка с peer-узлами содержит широкую таблицу. Из-за фиксированной ширины модального окна часть таблицы, включая кнопки действий, могла выходить за пределы окна и отображаться поверх затемнённого фона страницы.

### Что изменено

- Модальные окна, содержащие CBI-таблицы, теперь адаптивно расширяются до доступной ширины экрана.
- Максимальная ширина ограничена viewport’ом, чтобы окно не выходило за пределы экрана.
- На узких экранах таблица остаётся внутри модального окна и получает горизонтальный скролл при необходимости.
- Кнопки действий в строках таблицы сохраняются в одну линию.

---

## 🇬🇧

Fixed incorrect rendering of wide LuCI CBI tables inside modal dialogs.

The issue was visible, for example, on:

`Network → Interfaces → Edit WireGuard/AmneziaWG interface → Peers`

The peers tab contains a wide table. Because the modal dialog had a fixed width, part of the table, including row action buttons, could overflow outside the modal and render over the dimmed page background.

### What changed

- Modal dialogs containing CBI tables now adaptively expand up to the available viewport width.
- The maximum width is constrained by the viewport so the modal does not exceed the screen.
- On smaller screens, table overflow stays inside the modal and becomes horizontally scrollable when needed.
- Row action buttons are kept on a single line.
