### PR TITLE
fixes for custom color branding

### DIFF
--- a/htdocs/luci-static/proton2025/settings-sync.js
+++ b/htdocs/luci-static/proton2025/settings-sync.js
@@ -264,34 +264,21 @@
       // Set flag to prevent sync loop
       isSyncingFromUci = true;
 
-      const localAccent = localStorage.getItem("proton-accent-color");
-
+      // A deliberately-picked-but-not-yet-saved local value is already
+      // protected: syncFromUci() bails out at the top while hasPendingChanges()
+      // is true (that queue is persisted in sessionStorage across navigation).
+      // So by the time we get here UCI is authoritative for every option, the
+      // custom accent included — no per-option guard. Guarding the accent here
+      // used to make it "sticky" to whatever the browser had in localStorage
+      // and ignore the value shipped in /etc/config/proton2025 on a freshly
+      // flashed device (accent=custom + a stale/empty accent_custom fell back
+      // to the built-in #5e9eff instead of the configured colour).
       for (const [uciName, uciValue] of Object.entries(settings)) {
         const localKey = UCI_TO_LOCAL[uciName];
         if (!localKey) continue;
 
         const localValue = uciToLocal(uciName, uciValue);
         const currentLocal = localStorage.getItem(localKey);
-
-        // Never let a stale/uncommitted UCI value clobber a deliberately
-        // chosen local "custom" accent. If UCI hasn't caught up yet, keep
-        // the local choice and re-push it to UCI so it self-heals. This
-        // fixes the custom accent reverting to grey ("default") after
-        // navigating to another page.
-        if (localAccent === "custom") {
-          if (uciName === "accent" && localValue !== "custom") {
-            pendingChanges.accent = "custom";
-            const cu = localStorage.getItem("proton-accent-custom");
-            if (cu) pendingChanges.accent_custom = cu;
-            persistPendingChanges();
-            scheduleSaveToUci();
-            continue;
-          }
-          if (uciName === "accent_custom") {
-            // Keep whatever hex the user picked locally.
-            continue;
-          }
-        }
 
         // UCI takes precedence - update localStorage if different
         if (currentLocal !== localValue) {

--- a/ucode/template/themes/proton2025/sysauth.ut
+++ b/ucode/template/themes/proton2025/sysauth.ut
@@ -43,6 +43,11 @@
     var map = {
         mode: "proton-theme-mode",
         accent: "proton-accent-color",
+        // accent_custom must ride along with accent: without it the first-ever
+        // login (empty localStorage) sets accent="custom" but no hex, so the
+        // apply block below falls back to #5e9eff and the page looks blue until
+        // a later login populates localStorage from the main-UI sync.
+        accent_custom: "proton-accent-custom",
         zoom: "proton-zoom",
         transparency: "proton-transparency",
         border_radius: "proton-border-radius",


### PR DESCRIPTION
- Fixed a bug with initial router startup with fallback blue color accent if a custom color was set in settings