### PR TITLE
Tabs: tighten the gap under tab strips

### DIFF
--- a/htdocs/luci-static/proton2025/cascade.css
+++ b/htdocs/luci-static/proton2025/cascade.css
@@ -3830,7 +3830,7 @@ table.assoclist td[data-title="Скорость приёма / отправки"
     flex-wrap: wrap;
     gap: 4px;
     list-style: none;
-    margin: 0 0 24px;
+    margin: 0 0 12px;
     padding: 0;
     border-bottom: 1px solid var(--proton-border);
     position: relative;
@@ -3905,7 +3905,7 @@ table.assoclist td[data-title="Скорость приёма / отправки"
     flex-wrap: wrap;
     gap: 4px;
     list-style: none;
-    margin: 0 0 24px;
+    margin: 0 0 12px;
     padding: 0;
     border-bottom: 1px solid var(--proton-border);
     position: relative;


### PR DESCRIPTION
The `.cbi-tabmenu` / `#tabmenu` strips keep their 1px baseline (the tabs sit on it) and the active-tab accent underline, but the bottom gap between that baseline and the page content was 24px. On every tabbed page that made the line look detached from the tabs rather than being their baseline.

This reduces the gap to 12px so the baseline reads as the tabs' baseline again, with no extra empty space below it. Two-line change, no markup or behaviour changes.