### PR TITLE
tables: stop clipping open comboboxes, size their menus to the page

### DIFF
--- a/htdocs/luci-static/proton2025/cascade.css
+++ b/htdocs/luci-static/proton2025/cascade.css
@@ -2247,28 +2247,47 @@ table.cbi-section-table .cbi-section-actions .cbi-button+.cbi-button {
     margin-left: 0;
 }
 
-body:not([data-page^="admin-status"]) .cbi-tblsection {
+/* Горизонтальный скролл широких таблиц ЖИВЁТ НА ВНУТРЕННЕМ .table, а не на
+   секции: overflow:auto на секции превращал её в scroll-родителя открытых
+   комбобоксов (ui.js getScrollParent матчит любой auto) — меню обрезалось
+   карточкой и сжималось до высоты секции со скроллом внутри. Легаси-таблицы
+   тегом <table> скроллить сами не умеют — для них auto остаётся на секции. */
+body:not([data-page^="admin-status"]) .cbi-tblsection > .table {
     overflow-x: auto;
+}
+body:not([data-page^="admin-status"]) .cbi-tblsection:has(> table.cbi-section-table) {
+    overflow-x: auto;
+}
+
+/* Пока фокус в комбобоксе — обрезку отпускаем: браузер ставит фокус на
+   контрол ДО того, как ui.js меряет доступное место, поэтому меню получает
+   полную высоту страницы, а не высоту таблицы. */
+body:not([data-page^="admin-status"]) .cbi-tblsection > .table:has(.cbi-dropdown:focus-within),
+body:not([data-page^="admin-status"]) .cbi-tblsection:has(> table.cbi-section-table .cbi-dropdown:focus-within) {
+    overflow: visible;
 }
 
 /* Some GridSection tables have too many columns to fit the page width (e.g. the
    ZeroTier network list — ~10 flag columns, worse once headers are translated).
    They can't fit and custom-pages.js won't widen the page for them, so give the
    inevitable horizontal scroll a clean accent-tinted scrollbar. */
-body:not([data-page^="admin-status"]) .cbi-tblsection::-webkit-scrollbar {
+body:not([data-page^="admin-status"]) .cbi-tblsection::-webkit-scrollbar,
+body:not([data-page^="admin-status"]) .cbi-tblsection > .table::-webkit-scrollbar {
     height: 10px;
 }
 /* --proton-accent-rgb задаётся в :root обеих тем (94,158,255 dark /
    75,85,99 light), но на случай кастомных сборок/старого кэша даём
    fallback прямо в var(), иначе rgba() станет невалидной и скроллбар
    отрисуется системным. */
-body:not([data-page^="admin-status"]) .cbi-tblsection::-webkit-scrollbar-thumb {
+body:not([data-page^="admin-status"]) .cbi-tblsection::-webkit-scrollbar-thumb,
+body:not([data-page^="admin-status"]) .cbi-tblsection > .table::-webkit-scrollbar-thumb {
     background: rgba(var(--proton-accent-rgb, 94, 158, 255), 0.45);
     border: 2px solid transparent;
     border-radius: 8px;
     background-clip: padding-box;
 }
-body:not([data-page^="admin-status"]) .cbi-tblsection::-webkit-scrollbar-thumb:hover {
+body:not([data-page^="admin-status"]) .cbi-tblsection::-webkit-scrollbar-thumb:hover,
+body:not([data-page^="admin-status"]) .cbi-tblsection > .table::-webkit-scrollbar-thumb:hover {
     background: rgba(var(--proton-accent-rgb, 94, 158, 255), 0.7);
     background-clip: padding-box;
 }
@@ -4064,7 +4083,9 @@ table.assoclist td[data-title="Скорость приёма / отправки"
     border-radius: var(--proton-radius-sm);
     box-shadow: var(--proton-shadow);
     z-index: 10001;
-    max-height: 300px;
+    /* 300 обрезало типовые списки из 6-8 пунктов на пару пикселей - скролл
+       ради 5px. Реальную подгонку под вьюпорт делает ui.js инлайном. */
+    max-height: 360px;
     overflow-y: auto;
     min-width: 100%;
     width: max-content;
@@ -4094,7 +4115,9 @@ table.assoclist td[data-title="Скорость приёма / отправки"
 
 .cbi-dropdown[open]>ul.dropdown>li {
     display: flex;
-    padding: 10px 14px;
+    /* Плотнее, чем в закрытом контроле: открытое меню соседствует с нативным
+       select и не должно выглядеть вдвое крупнее его пунктов. */
+    padding: 7px 12px;
     border-bottom: 1px solid var(--proton-border-light);
     transition: var(--proton-transition);
     background: #1e2530 !important;
@@ -4123,6 +4146,26 @@ table.assoclist td[data-title="Скорость приёма / отправки"
 .cbi-dropdown[open]>ul.dropdown>li[selected] {
     background: #252f3d !important;
     color: var(--proton-accent);
+}
+
+/* Строка свободного ввода в комбобоксе: компактная и в тон меню. */
+.cbi-dropdown[open]>ul.dropdown>li>input.create-item-input {
+    width: 100%;
+    min-width: 0;
+    padding: 4px 8px;
+    background: var(--proton-bg-tertiary);
+    border: 1px solid var(--proton-border);
+    border-radius: var(--proton-radius-sm);
+    color: inherit;
+}
+
+/* Вертикальный скролл открытого меню - тонкий, как остальные в теме. */
+.cbi-dropdown[open]>ul.dropdown::-webkit-scrollbar {
+    width: 8px;
+}
+.cbi-dropdown[open]>ul.dropdown::-webkit-scrollbar-thumb {
+    background: rgba(var(--proton-accent-rgb, 94, 158, 255), 0.45);
+    border-radius: 8px;
 }
 
 /* =====================================================


### PR DESCRIPTION
Open LuCI comboboxes inside table sections (`.cbi-tblsection`) were broken in two ways, both caused by the section's `overflow-x: auto`:

1. the section clipped the absolutely-positioned open menu, so it was cut off at the card edge;
2. `ui.js getScrollParent` matches any `auto` overflow, so the menu height was computed against the section box — an inline `max-height` of ~130px, a 3-item window with a scrollbar while the page had plenty of room.

Live example: the ping-host combobox on a settings page — the list opened as a tiny scrolling window clipped by the card.

**Fix:**
- horizontal scrolling moves to the inner `.table` child; legacy `<table>`-tag grids (e.g. ZeroTier's wide network list) can't scroll themselves, so they keep it on the section via `:has(> table.cbi-section-table)`;
- while a combobox inside holds focus, the clip is released (`:has(.cbi-dropdown:focus-within)`). The control receives focus on mousedown — before `openDropdown` measures space — so the menu gets the full page height. Verified on a live router;
- open-menu items densified to `7px 12px` so the menu doesn't look twice the size of a native select;
- theme menu cap raised 300 → 360px (typical 6–8 item lists were being cut by a few pixels, scrolling for nothing);
- accent-styled vertical scrollbar for the menu, and the free-entry `create-item-input` row styled to match the menu.

Before/after: the ping-host list now renders fully above the card, no inner scroll, matching the look of native selects.